### PR TITLE
make result app ligthweight

### DIFF
--- a/vote-apps/result-app/Dockerfile
+++ b/vote-apps/result-app/Dockerfile
@@ -1,12 +1,11 @@
-#FROM node:0.10
-FROM hypriot/rpi-node:latest
+FROM hypriot/rpi-node:slim
 
-RUN mkdir /app
 WORKDIR /app
 
 ADD package.json /app/package.json
-RUN npm install && npm ls
-RUN mv /app/node_modules /node_modules
+RUN npm install \
+	&& npm ls \
+	&& mv /app/node_modules /node_modules
 
 ADD . /app
 


### PR DESCRIPTION
THis MR use 2 tricks for that : 
- Using the "slim" imageof hypirot/rpi-node which is still raspbian based but have only 160 Mo instead of ~410 Mo...
- 1 layers removed : the RUN mkdir /app is not needed since WORKDIR will do it (maybe it was done for dealing with folder rights ?)
- Other RUN have been flattened

Resut : 

```
root@scw-c4dcc6:~/ddu/rpi-voting-app/vote-apps# docker images
REPOSITORY                   TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
voteapps_result-app          latest              930df992b149        41 seconds ago      161.1 MB
```

And it works ! :) http://163.172.128.46:5001/
